### PR TITLE
Update test URL

### DIFF
--- a/src/client/paparaRequest.ts
+++ b/src/client/paparaRequest.ts
@@ -28,7 +28,7 @@ export class PaparaRequest {
   url_live = "https://merchant-api.papara.com";
 
   // Test environment URL.
-  url_test = "https://merchant.test.api.papara.com";
+  url_test = "https://merchant-api.test.papara.com";
 
   /**
    * Creates an instance of papara request.


### PR DESCRIPTION
According to the [papara documentation](https://merchant-api.papara.com/) the new test URL is: `https://merchant-api.test.papara.com`

With current configuration we receive this error:
```Error: FetchError: request to https://merchant.test.api.papara.com/payments failed, reason: getaddrinfo ENOTFOUND merchant.test.api.papara.com
    at PaparaHttpClient.<anonymous> (/home/mgorunuch/projects/old-backup/tiptok/backend/node_modules/@papara/papara/src/client/httpClient.ts:57:13)
    at step (/home/mgorunuch/projects/old-backup/tiptok/backend/node_modules/@papara/papara/dist/client/httpClient.js:33:23)
    at Object.throw (/home/mgorunuch/projects/old-backup/tiptok/backend/node_modules/@papara/papara/dist/client/httpClient.js:14:53)
    at rejected (/home/mgorunuch/projects/old-backup/tiptok/backend/node_modules/@papara/papara/dist/client/httpClient.js:6:65)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
``